### PR TITLE
Atomic current update

### DIFF
--- a/lib/tpmongo.js
+++ b/lib/tpmongo.js
@@ -14,13 +14,13 @@ var CurrentStatus = {
 
 // *****************************************************************************
 // Constructors and pmongo pointers
-var TemporalMongo = function(connectionString, collections) {
+var TemporalMongo = function(connectionString, collections, collectionConfig) {
   var db = pmongo(connectionString, collections);
   db.proxyCollections = {};
 
   _.forEach(collections, function(collectionName) {
     db.proxyCollections[collectionName] = db[collectionName];
-    db[collectionName] = new TemporalCollection(collectionName, db[collectionName]._get);
+    db[collectionName] = new TemporalCollection(collectionName, db[collectionName]._get, collectionConfig);
     db[collectionName].proxyCollection = db.proxyCollections[collectionName];
   });
 
@@ -256,6 +256,7 @@ TemporalCollection.prototype.makeClone = function(sourceDocument, currentDate, t
 
   clone._current = CurrentStatus.InProgressClone;
   clone._startDate = currentDate;
+  clone._endDate = this.config._maxDate;
   clone._cloneTranId = tranId;
   return clone;
 };
@@ -273,7 +274,7 @@ TemporalCollection.prototype.update = function(query, docUpdate, options, transa
   var lockedDocumentCount = 0;
 
   _this.info('Starting Phase 1');
-  return _this.updateRaw(queryForCurrent, {$push: {_tranIds: tranId}}, optionsForLocking)
+  return _this.updateRaw(queryForCurrent, {$push: {_tranIds: tranId}, $set: {_endDate: currentDate}}, optionsForLocking)
   .then(function(updateResult) {
     lockedDocumentCount = updateResult.n;
     return _this.findRaw(queryForCurrentByTransaction).toArray();
@@ -322,15 +323,13 @@ TemporalCollection.prototype.update = function(query, docUpdate, options, transa
       .then(function() {
         _this.info('Starting Phase 3');
         // PHASE 3, update clone
-        _this.addUnsetterToUpdate(docUpdate, '_cloneTranId');
-        _this.addSetterToUpdate(docUpdate, '_current', CurrentStatus.Current);
         _this.info(JSON.stringify(docUpdate));
         return _this.updateRaw({_cloneTranId: tranId}, docUpdate, {multi: true, writeConcern: 'majority'});
       }, function(cloneInsertError) {
         //rollback locked docs
         console.log('tpmongo cloneInsertError - check unique indexes');
         console.log(cloneInsertError);
-        return _this.updateRaw({_tranIds: tranId}, {$pull: { _tranIds: tranId }}, {multi: true, writeConcern: 'majority'})
+        return _this.updateRaw({_tranIds: tranId}, {$pull: { _tranIds: tranId }, $set: { _endDate: _this.config._maxDate }}, {multi: true, writeConcern: 'majority'})
         .then(function() {
           return Q.reject(_this.TemporalMongoError('CLONE_INSERTS_FAILED', 
             'The clone insert(s) failed: '));
@@ -341,12 +340,31 @@ TemporalCollection.prototype.update = function(query, docUpdate, options, transa
       })
       .then(function() {
         _this.info('Starting Phase 4');
-        // PHASE 4, unlock and archive original
-        var unlockingQuery = {_current: CurrentStatus.Current, '_tranIds.0': tranId };
-        var unlockingUpdate = {$set: {_current: CurrentStatus.Archived, _endDate: currentDate}, $pull: {_tranIds: tranId}};
+        // PHASE 4: simultaneously:
+        // * unlock and archive originals
+        // * set clones as current
+        var unlockingQuery = {
+          $or: [{
+            '_tranIds.0': tranId
+          }, {
+            _cloneTranId: tranId
+          }]
+        };
+        var unlockingUpdate = {
+          $inc: { _current: -1 },
+          $unset: { _cloneTranId: '' },
+          $pull: { _tranIds: tranId }
+        };
         return _this.updateRaw(unlockingQuery, unlockingUpdate, {multi: true, writeConcern: 'majority'})
         .then(function(updateResult) {
-          return Q.when(updateResult);
+          if(updateResult.n !== 2*lockedDocumentCount) {
+            return Q.reject(_this.TemporalMongoError('LOCK_RELEASE_FAILED',
+              'Incorrect number of clones and current documents updated. Expected: ' + 2*lockedDocumentCount + '. Got: ' + updateResult.n));
+          }
+          // Remap the updated doc count since we updated all clones and currents in 1 step
+          var result = _.omit(updateResult, 'n');
+          result.n = lockedDocumentCount;
+          return Q.when(result);
         }, function(err) {
           return Q.reject(_this.TemporalMongoError('LOCK_RELEASE_FAILED', 
             'The lock release failed: ' + JSON.stringify(err)));

--- a/test/tpmongo_test.js
+++ b/test/tpmongo_test.js
@@ -7,12 +7,13 @@ var massInsertCount = 1000;
 describe('tpmongo', function () {
 
   //setup 
+  var maxDate = new Date('2099-07-21 15:16:00.599Z');
   var mongoCollections = ['tempCollection'];
-  var db = tpmongo('localhost/mongoTestDb', mongoCollections);
+  var db = tpmongo('localhost/mongoTestDb', mongoCollections, { _maxDate: maxDate });
 
   var testObjectId = db.ObjectId('95addf649ce171641a34281e');
   var testStartDate = new Date('2015-07-21 15:16:00.599Z');
-  var testEndDate = new Date('2099-07-21 15:16:00.599Z');
+  var testEndDate = maxDate;
   var testMiddleDate = new Date('2015-07-22 15:16:00.599Z');
 
   var setupDocuments = function() {
@@ -114,7 +115,7 @@ describe('tpmongo', function () {
       return db.tempCollection.cleanLocks();
     })
     .then(function() {
-      return db.tempCollection.countRaw({$or: [{_tranIds: {$exists: true}}, {_current: {$eq: -1}}, {_locked: {$exists: true}}]});
+      return db.tempCollection.countRaw({$or: [{_tranIds: {$exists: true}}, {_current: {$eq: 2}}, {_locked: {$exists: true}}]});
     })
     .then(function(result) {
       badDocCount = result;


### PR DESCRIPTION
This PR addresses an issue where `findAndModify()` and `update()` would at one point during their operation have cloned documents **and** original documents **both** have `_current === 1`. This situation would cause a unique constraint violation if one existed for any field in the documents.

The main idea is that rather than setting all clones to `_current = 1` and then setting all originals to archived, we instead:
- Have `InProgressClone` state value be 2 (instead of -1)
- Use the `$inc` operator to perform a state transition of all documents that are being operated on in one database call
  - While this doesn't guarantee atomicity (the update could technically fail partway through), it does **not** cause a unique constraint violation. And at least it's one db roundtrip.
